### PR TITLE
fix missing specifiers in bet_settlement

### DIFF
--- a/bet_settlement.go
+++ b/bet_settlement.go
@@ -16,8 +16,9 @@ type BetSettlement struct {
 }
 
 type BetSettlementMarket struct {
-	ID     int `xml:"id,attr" json:"id"`
-	LineID int `json:"lineID"`
+	ID         int               `xml:"id,attr" json:"id"`
+	LineID     int               `json:"lineID"`
+	Specifiers map[string]string `json:"specifiers,omitempty"`
 	// Describes the reason for voiding certain outcomes for a particular market.
 	// Only set if at least one of the outcomes have a void_factor. A list of void
 	// reasons can be found above this table or by using the API at
@@ -80,6 +81,7 @@ func (t *BetSettlementMarket) UnmarshalXML(d *xml.Decoder, start xml.StartElemen
 	if err := d.DecodeElement(&overlay, &start); err != nil {
 		return err
 	}
+	t.Specifiers = toSpecifiers(overlay.Specifiers, overlay.ExtendedSpecifiers)
 	t.LineID = toLineID(overlay.Specifiers)
 	return nil
 }


### PR DESCRIPTION
-- reason: some markets can come as late as bet_settlement
-- for markets coming in that late there was no odds_change message was ever received so they do not have specifiers
-- example of the issue: eventID 20227321, market id="237" specifiers="hcp=-12.5"
-- solution: added specifiers in BetSettlementMarket and its UnmarshalXML

Part of log dump:
```12:04:46.236 market_template.go:32 invalid name lang:9 template:{$competitor1} ({+hcp}) marketID:203 specifiers:map[] competitors:[GAB RAJ] isOutcome:true
12:04:46.237 market_template.go:32 invalid name lang:9 template:{$competitor2} ({-hcp}) marketID:203 specifiers:map[] competitors:[GAB RAJ] isOutcome:true
12:04:46.237 market_template.go:32 invalid name lang:9 template:{$competitor1} ({+hcp}) marketID:203 specifiers:map[] competitors:[GAB RAJ] isOutcome:true
12:04:46.237 market_template.go:32 invalid name lang:9 template:{$competitor2} ({-hcp}) marketID:203 specifiers:map[] competitors:[GAB RAJ] isOutcome:true
12:04:46.237 market_template.go:32 invalid name lang:9 template:{$competitor1} ({+hcp}) marketID:203 specifiers:map[] competitors:[GAB RAJ] isOutcome:true
12:04:46.238 market_template.go:32 invalid name lang:9 template:{$competitor2} ({-hcp}) marketID:203 specifiers:map[] competitors:[GAB RAJ] isOutcome:true
12:04:46.238 market_template.go:32 invalid name lang:9 template:{$competitor2} ({-hcp}) marketID:203 specifiers:map[] competitors:[GAB RAJ] isOutcome:true
12:04:46.238 market_template.go:32 invalid name lang:9 template:{$competitor1} ({+hcp}) marketID:203 specifiers:map[] competitors:[GAB RAJ] isOutcome:true
12:04:46.238 market_template.go:32 invalid name lang:9 template:{$competitor1} ({+hcp}) marketID:203 specifiers:map[] competitors:[GAB RAJ] isOutcome:true
12:04:46.238 market_template.go:32 invalid name lang:9 template:{$competitor2} ({-hcp}) marketID:203 specifiers:map[] competitors:[GAB RAJ] isOutcome:true