### PR TITLE
add copy of producer and timestamp to UOFMessage.Header

### DIFF
--- a/message.go
+++ b/message.go
@@ -21,6 +21,8 @@ type Header struct {
 	EventURN    URN             `json:"eventURN,omitempty"`
 	ReceivedAt  int             `json:"receivedAt,omitempty"`
 	RequestedAt int             `json:"requestedAt,omitempty"`
+	Producer    Producer        `json:"producer,omitempty"`
+	Timestamp   int             `json:"timestamp,omitempty"`
 }
 
 type Body struct {
@@ -134,6 +136,7 @@ func (m *Message) parseRoutingKey(routingKey string) error {
 	return nil
 }
 
+// after unmarshall copy producer and timestamp to Header
 func (m *Message) unpack() error {
 	if m.Raw == nil {
 		return nil
@@ -148,30 +151,48 @@ func (m *Message) unpack() error {
 	case MessageTypeAlive:
 		m.Alive = &Alive{}
 		unmarshal(m.Alive)
+		m.Timestamp = m.Alive.Timestamp
+		m.Producer = m.Alive.Producer
 	case MessageTypeBetCancel:
 		m.BetCancel = &BetCancel{}
 		unmarshal(m.BetCancel)
+		m.Timestamp = m.BetCancel.Timestamp
+		m.Producer = m.BetCancel.Producer
 	case MessageTypeBetSettlement:
 		m.BetSettlement = &BetSettlement{}
 		unmarshal(m.BetSettlement)
+		m.Timestamp = m.BetSettlement.Timestamp
+		m.Producer = m.BetSettlement.Producer
 	case MessageTypeBetStop:
 		m.BetStop = &BetStop{}
 		unmarshal(m.BetStop)
+		m.Timestamp = m.BetStop.Timestamp
+		m.Producer = m.BetStop.Producer
 	case MessageTypeFixtureChange:
 		m.FixtureChange = &FixtureChange{}
 		unmarshal(m.FixtureChange)
+		m.Timestamp = m.FixtureChange.Timestamp
+		m.Producer = m.FixtureChange.Producer
 	case MessageTypeOddsChange:
 		m.OddsChange = &OddsChange{}
 		unmarshal(m.OddsChange)
+		m.Timestamp = m.OddsChange.Timestamp
+		m.Producer = m.OddsChange.Producer
 	case MessageTypeRollbackBetSettlement:
 		m.RollbackBetSettlement = &RollbackBetSettlement{}
 		unmarshal(m.RollbackBetSettlement)
+		m.Timestamp = m.RollbackBetSettlement.Timestamp
+		m.Producer = m.RollbackBetSettlement.Producer
 	case MessageTypeRollbackBetCancel:
 		m.RollbackBetCancel = &RollbackBetCancel{}
 		unmarshal(m.RollbackBetCancel)
+		m.Timestamp = m.RollbackBetCancel.Timestamp
+		m.Producer = m.RollbackBetCancel.Producer
 	case MessageTypeSnapshotComplete:
 		m.SnapshotComplete = &SnapshotComplete{}
 		unmarshal(m.SnapshotComplete)
+		m.Timestamp = m.SnapshotComplete.Timestamp
+		m.Producer = m.SnapshotComplete.Producer
 	case MessageTypeFixture:
 		fr := FixtureRsp{}
 		unmarshal(&fr)

--- a/message_test.go
+++ b/message_test.go
@@ -128,7 +128,7 @@ func TestMessageTypeParse(t *testing.T) {
 
 func TestMessageWithRawMarshal(t *testing.T) {
 	m := &Message{
-		Header: Header{Type: MessageTypeAlive, Scope: MessageScopeSystem, Priority: MessagePriorityLow, ReceivedAt: 12345},
+		Header: Header{Type: MessageTypeAlive, Scope: MessageScopeSystem, Priority: MessagePriorityLow, ReceivedAt: 12345, Producer: ProducerPrematch, Timestamp: 12340},
 		Raw:    []byte(`<alive product="3" timestamp="12340" subscribed="1"/>`),
 		Body: Body{
 			Alive: &Alive{
@@ -140,7 +140,7 @@ func TestMessageWithRawMarshal(t *testing.T) {
 	}
 
 	buf := m.Marshal()
-	expected := []byte(`{"type":64,"scope":4,"receivedAt":12345}
+	expected := []byte(`{"type":64,"scope":4,"receivedAt":12345,"producer":3,"timestamp":12340}
 <alive product="3" timestamp="12340" subscribed="1"/>`)
 	assert.Equal(t, expected, buf)
 

--- a/message_test.go
+++ b/message_test.go
@@ -293,3 +293,180 @@ func TestUnpackFail(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, `NOTICE uof error op: message.unpack, inner: unknown message type -1`, err.Error())
 }
+
+func TestEnrichHeaderAfterUnpack(t *testing.T) {
+	// check if Producer and Timestamp get copied to Header after Unmarshal
+	// all messages have the same producer and the same timestamp in ms (1234578910111)
+	buf := []struct {
+		key string
+		raw []byte
+	}{
+		// snapshot_complete
+		struct {
+			key string
+			raw []byte
+		}{
+			key: "-.-.-.snapshot_complete.-.-.-",
+			raw: []byte(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+			<snapshot_complete request_id="1234" timestamp="1234578910111" product="1"/>`),
+		},
+		// alive
+		struct {
+			key string
+			raw []byte
+		}{
+			key: "-.-.-.alive.-.-.-.-",
+			raw: []byte(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+			<alive product="1" timestamp="1234578910111" subscribed="1"/>`),
+		},
+		// fixture_change
+		struct {
+			key string
+			raw []byte
+		}{
+			key: "hi.pre.live.fixture_change.1.sr:match.18001015.-",
+			raw: []byte(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+			<fixture_change start_time="1557255600000" product="1" event_id="sr:match:18001015" timestamp="1234578910111"/>`),
+		},
+		// bet_stop
+		struct {
+			key string
+			raw []byte
+		}{
+			key: "hi.-.live.bet_stop.1.sr:match.18001015.-",
+			raw: []byte(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+			<bet_stop groups="all" market_status="0" product="1" event_id="sr:match:18001015" timestamp="1234578910111"/>`),
+		},
+		// odds_change
+		struct {
+			key string
+			raw []byte
+		}{
+			key: "hi.-.live.odds_change.1.sr:match.18001015.-",
+			raw: []byte(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+		<odds_change product="1" event_id="sr:match:18001015" timestamp="1234578910111">
+			<sport_event_status status="0" match_status="0"/>
+			<odds>
+				<market status="1" id="1">
+					<outcome id="1" odds="2.08" probabilities="0.450633" active="1"/>
+					<outcome id="2" odds="3.31" probabilities="0.277172" active="1"/>
+					<outcome id="3" odds="3.37" probabilities="0.272194" active="1"/>
+				</market>
+			</odds>
+		</odds_change>`),
+		},
+		// bet_settlement
+		struct {
+			key string
+			raw []byte
+		}{
+			key: "hi.-.live.bet_settlement.1.sr:match.18001015.-",
+			raw: []byte(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+		<bet_settlement certainty="1" product="1" event_id="sr:match:13369905" timestamp="1234578910111">
+			<outcomes>
+				<market id="6">
+					<outcome id="4" result="1"/>
+					<outcome id="5" result="0"/>
+				</market>
+			</outcomes>
+		</bet_settlement>`),
+		},
+		// rollback_bet_settlement
+		struct {
+			key string
+			raw []byte
+		}{
+			key: "hi.-.live.rollback_bet_settlement.1.sr:match.18001015.-",
+			raw: []byte(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+			<rollback_bet_settlement product="1" event_id="sr:match:18001015" timestamp="1234578910111">
+				<market id="38" specifiers="goalnr=1|type=live"/>
+			</rollback_bet_settlement>`),
+		},
+		// bet_cancel
+		struct {
+			key string
+			raw []byte
+		}{
+			key: "hi.-.live.bet_cancel.1.sr:match.18001015.-",
+			raw: []byte(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+		<bet_cancel end_time="1564598513000" event_id="sr:match:18001015" product="1" start_time="1564597838000" timestamp="1234578910111">
+			<market name="1st half - 1st goal" id="62" specifier="goalnr=1" void_reason="12"/>
+		</bet_cancel>`),
+		},
+		// rollback_bet_cancel
+		struct {
+			key string
+			raw []byte
+		}{
+			key: "hi.-.live.rollback_bet_cancel.1.sr:match.18001015.-",
+			raw: []byte(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+			<rollback_bet_cancel event_id="sr:match:4444" product="1" timestamp="1234578910111">
+				<market id="48" specifiers="score=41.5"/>
+			</rollback_bet_cancel>`),
+		},
+	}
+
+	for _, m := range buf {
+		qm, err := NewQueueMessage(m.key, m.raw)
+		assert.Nil(t, err)
+		if err != nil {
+			t.Logf(err.Error())
+		}
+		assert.NotNil(t, qm)
+		assert.Equal(t, ProducerLiveOdds, qm.Producer)
+		assert.Equal(t, 1234578910111, qm.Timestamp)
+		assert.Equal(t, getTsFromMsg(qm), qm.Timestamp)
+		assert.Equal(t, getProducerFromMsg(qm), qm.Producer)
+		t.Logf("prod: %s ts: %d msg type: %s \n", qm.Producer, qm.Timestamp, qm.Type.String())
+	}
+}
+
+// get timestamp from embedded message type
+func getTsFromMsg(msg *Message) int {
+	switch msg.Type {
+	case MessageTypeOddsChange:
+		return msg.OddsChange.Timestamp
+	case MessageTypeFixtureChange:
+		return msg.FixtureChange.Timestamp
+	case MessageTypeBetStop:
+		return msg.BetStop.Timestamp
+	case MessageTypeBetSettlement:
+		return msg.BetSettlement.Timestamp
+	case MessageTypeRollbackBetSettlement:
+		return msg.RollbackBetSettlement.Timestamp
+	case MessageTypeBetCancel:
+		return msg.BetCancel.Timestamp
+	case MessageTypeRollbackBetCancel:
+		return msg.RollbackBetCancel.Timestamp
+	case MessageTypeSnapshotComplete:
+		return msg.SnapshotComplete.Timestamp
+	case MessageTypeAlive:
+		return msg.Alive.Timestamp
+	}
+	return 0
+}
+
+// get producer from embedded message type
+func getProducerFromMsg(msg *Message) Producer {
+	switch msg.Type {
+	case MessageTypeOddsChange:
+		return msg.OddsChange.Producer
+	case MessageTypeFixtureChange:
+		return msg.FixtureChange.Producer
+	case MessageTypeBetStop:
+		return msg.BetStop.Producer
+	case MessageTypeBetSettlement:
+		return msg.BetSettlement.Producer
+	case MessageTypeRollbackBetSettlement:
+		return msg.RollbackBetSettlement.Producer
+	case MessageTypeBetCancel:
+		return msg.BetCancel.Producer
+	case MessageTypeRollbackBetCancel:
+		return msg.RollbackBetCancel.Producer
+	case MessageTypeSnapshotComplete:
+		return msg.SnapshotComplete.Producer
+	case MessageTypeAlive:
+		return msg.Alive.Producer
+	}
+	return ProducerUnknown
+}


### PR DESCRIPTION
-- having producer and timestamp in Header makes downstream filtering
easier to read and cleaner to write
-- this will enable filtering messages by producer and checking time lag without
knowing the actual message type
-- previously, messages had to be checked for type because producer and timestamp
were written only in the specific embedded message (OddsChange, FixtureChande, BetSettlement etc.)
-- this way a message can be piped to its corresponding consumer without knowing its type
-- expanded tests to verify new behaviour