### PR TITLE
bugfix: resolve negative waitgroup counter panic on SDK exit

### DIFF
--- a/pipe/recovery.go
+++ b/pipe/recovery.go
@@ -110,9 +110,8 @@ func (r *recovery) requestRecovery(p *recoveryProducer) {
 
 	r.subProcs.Add(1)
 	go func(producer uof.Producer, timestamp int, requestID int) {
+		defer r.subProcs.Done()
 		for {
-			defer r.subProcs.Done()
-
 			op := fmt.Sprintf("recovery for %s, timestamp: %d, requestID: %d", producer.Code(), timestamp, requestID)
 			r.log(fmt.Errorf("starting %s", op))
 			err := r.api.RequestRecovery(producer, timestamp, requestID)


### PR DESCRIPTION
Bug was caused by calling WaitGroup.Done() inside an infinite loop.

The issue would not occur if the recovery was successful, but would in case the Betradar Producer was down or not available for some reasons.

Each time the recovery would fail, there would be an additional defer WG.Done() call, but with only one WG.Add(1) call just before spawning the recovery goroutine.

With this patch SDK no longer panics on exit.

Associated BaseCamp task:
https://3.basecamp.com/3077084/buckets/13717705/todos/2476389286