### PR TITLE
parse extra_info in uof.Fixture

### DIFF
--- a/fixture.go
+++ b/fixture.go
@@ -48,7 +48,7 @@ type Fixture struct {
 	//DelayedInfo DelayedInfo `xml:"delayed_info,omitempty" json:"delayedInfo,omitempty"`
 	//CoverageInfo CoverageInfo `xml:"coverage_info,omitempty" json:"coverageInfo,omitempty"`
 	//Races        []SportEvent `xml:"races>sport_event,omitempty" json:"races,omitempty"`
-	//ExtraInfo   ExtraInfo    `xml:"extra_info,omitempty" json:"extraInfo,omitempty"`
+	ExtraInfo []ExtraInfo `xml:"extra_info>info,omitempty" json:"extraInfo,omitempty"`
 	//ScheduledStartTimeChanges []ScheduledStartTimeChange `xml:"scheduled_start_time_changes>scheduled_start_time_change,omitempty" json:"scheduledStartTimeChanges,omitempty"`
 	//Parent *ParentStage `xml:"parent,omitempty" json:"parent,omitempty"`
 
@@ -161,6 +161,13 @@ type ProductInfo struct {
 	IsInLiveCenterSoccer string             `xml:"is_in_live_center_soccer,omitempty" json:"isInLiveCenterSoccer,omitempty"`
 	IsAutoTraded         string             `xml:"is_auto_traded,omitempty" json:"isAutoTraded,omitempty"`
 	Links                []ProductInfoLink  `xml:"links>link,omitempty" json:"links,omitempty"`
+}
+
+// ExtraInfo covers additional fixture information about the match,
+// such as coverage information, extended markets offer, additional rules etc.
+type ExtraInfo struct {
+	Key   string `xml:"key,attr,omitempty" json:"key,omitempty"`
+	Value string `xml:"value,attr,omitempty" json:"value,omitempty"`
 }
 
 func (f *Fixture) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {

--- a/parsing_test.go
+++ b/parsing_test.go
@@ -314,6 +314,21 @@ func TestFixture(t *testing.T) {
 	assert.Equal(t, 2953, f.Home.ID)
 	assert.Equal(t, 33, f.Away.ID)
 
+	// <extra_info>
+	// 	<info key="neutral_ground" value="false"/>
+	//  ...
+	// </extra_info>
+	assert.Equal(t, "neutral_ground", f.ExtraInfo[0].Key)
+	assert.Equal(t, "false", f.ExtraInfo[0].Value)
+	assert.Equal(t, "period_length", f.ExtraInfo[1].Key)
+	assert.Equal(t, "45", f.ExtraInfo[1].Value)
+	assert.Equal(t, "overtime_length", f.ExtraInfo[2].Key)
+	assert.Equal(t, "15", f.ExtraInfo[2].Value)
+	assert.Equal(t, "coverage_source", f.ExtraInfo[3].Key)
+	assert.Equal(t, "tv", f.ExtraInfo[3].Value)
+	assert.Equal(t, "extended_live_markets_offered", f.ExtraInfo[4].Key)
+	assert.Equal(t, "true", f.ExtraInfo[4].Value)
+
 	msg, err := NewAPIMessage(LangEN, MessageTypeFixture, buf)
 	assert.NoError(t, err)
 	assert.Equal(t, f, *msg.Fixture)


### PR DESCRIPTION
extra_info fixture tag has additional information about certain match conditions
such as extrended live markets availability, surface type, extra rules such as super tiebreak etc.