### PR TITLE
add Raw field to uof.Fixture resulting from fixture_change

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -112,6 +112,11 @@ func (a *API) getAs(o interface{}, tpl string, p *params) error {
 	if err := xml.Unmarshal(buf, o); err != nil {
 		return uof.Notice("unmarshal", err)
 	}
+	// assert FixtureRsp and inject raw
+	fx, ok := o.(*fixtureRsp)
+	if ok {
+		fx.Fixture.Raw = buf
+	}
 	return nil
 }
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -94,6 +94,12 @@ func testFixture(t *testing.T, a *API) {
 	f, err := a.Fixture(lang, "sr:match:8696826")
 	assert.Nil(t, err)
 	assert.Equal(t, "IK Oddevold", f.Home.Name)
+	// for fixtures raw response should be kept
+	assert.NotEqual(t, 0, len(f.Raw))
+	if testing.Verbose() && len(f.Raw) != 0 {
+		// strip <?xml version="1.0" encoding="UTF-8"?>
+		fmt.Printf("\t%s\n", f.Raw[39:100])
+	}
 }
 
 func testPlayer(t *testing.T, a *API) {

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -96,7 +96,7 @@ func logMessage(m *uof.Message) {
 	case uof.MessageTypeConnection:
 		fmt.Printf("%-25s status: %s\n", m.Type, m.Connection.Status)
 	case uof.MessageTypeFixture:
-		fmt.Printf("%-25s lang: %s, urn: %s\n", m.Type, m.Lang, m.Fixture.URN)
+		fmt.Printf("%-25s lang: %s, urn: %s raw: %d\n", m.Type, m.Lang, m.Fixture.URN, len(m.Fixture.Raw))
 	case uof.MessageTypeMarkets:
 		fmt.Printf("%-25s lang: %s, count: %d\n", m.Type, m.Lang, len(m.Markets))
 	case uof.MessageTypeAlive:

--- a/fixture.go
+++ b/fixture.go
@@ -42,13 +42,15 @@ type Fixture struct {
 
 	Home Competitor `json:"home"`
 	Away Competitor `json:"away"`
+
+	ExtraInfo []ExtraInfo `xml:"extra_info>info,omitempty" json:"extraInfo,omitempty"`
+	Raw       []byte      // fixture API raw XML response; keep for downstream processing
 	// this also exists but we are skiping for the time being
 	//ReferenceIDs         ReferenceIDs         `xml:"reference_ids,omitempty" json:"referenceIDs,omitempty"`
 	//SportEventConditions SportEventConditions `xml:"sport_event_conditions,omitempty" json:"sportEventConditions,omitempty"`
 	//DelayedInfo DelayedInfo `xml:"delayed_info,omitempty" json:"delayedInfo,omitempty"`
 	//CoverageInfo CoverageInfo `xml:"coverage_info,omitempty" json:"coverageInfo,omitempty"`
 	//Races        []SportEvent `xml:"races>sport_event,omitempty" json:"races,omitempty"`
-	ExtraInfo []ExtraInfo `xml:"extra_info>info,omitempty" json:"extraInfo,omitempty"`
 	//ScheduledStartTimeChanges []ScheduledStartTimeChange `xml:"scheduled_start_time_changes>scheduled_start_time_change,omitempty" json:"scheduledStartTimeChanges,omitempty"`
 	//Parent *ParentStage `xml:"parent,omitempty" json:"parent,omitempty"`
 

--- a/message.go
+++ b/message.go
@@ -293,6 +293,7 @@ func NewFixtureMessage(lang Lang, x Fixture, requestedAt int) *Message {
 			ReceivedAt:  uniqTimestamp(),
 			RequestedAt: requestedAt,
 		},
+		Raw:  x.Raw,
 		Body: Body{Fixture: &x},
 	}
 }

--- a/parsing_test.go
+++ b/parsing_test.go
@@ -329,9 +329,19 @@ func TestFixture(t *testing.T) {
 	assert.Equal(t, "extended_live_markets_offered", f.ExtraInfo[4].Key)
 	assert.Equal(t, "true", f.ExtraInfo[4].Value)
 
-	msg, err := NewAPIMessage(LangEN, MessageTypeFixture, buf)
+	// test creating uof.Message
+	msgAPI, err := NewAPIMessage(LangEN, MessageTypeFixture, buf)
 	assert.NoError(t, err)
-	assert.Equal(t, f, *msg.Fixture)
+	assert.Equal(t, f, *msgAPI.Fixture)
+
+	f.Raw = buf // enrich with raw API reponse
+	requestedAt := int(time.Now().UnixNano() / 1e6)
+	msgFromFix := NewFixtureMessage(LangEN, f, requestedAt)
+	assert.NotNil(t, msgFromFix)
+	assert.NotEqual(t, 0, len(msgFromFix.Raw))
+	assert.Len(t, msgFromFix.Raw, 5283)
+	assert.Len(t, msgFromFix.Fixture.Raw, 5283)
+	assert.Equal(t, &msgFromFix.Fixture.Raw, &msgFromFix.Raw)
 }
 
 func TestFixutreWithPlayers(t *testing.T) {


### PR DESCRIPTION
Having raw fixture XML is useful for downstream debugging.
This covers fixtures coming in as a result of an API poll initiated by a fixture_change message.
The endpoint that is being polled: /v1/sports/<Lang>/sport_events/<EventURN>/fixture.xml.

Fixtures coming from live or prematch schedule will not have the raw XML.
This requires custom decoding with chunking of the schedule response
to keep each fixture subelement inside a generated fixture uof.Message.