### PR TITLE
add Raw fixture to uof.Message

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -112,11 +112,6 @@ func (a *API) getAs(o interface{}, tpl string, p *params) error {
 	if err := xml.Unmarshal(buf, o); err != nil {
 		return uof.Notice("unmarshal", err)
 	}
-	// assert FixtureRsp and inject raw
-	fx, ok := o.(*fixtureRsp)
-	if ok {
-		fx.Fixture.Raw = buf
-	}
 	return nil
 }
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -92,14 +93,10 @@ func testMarketVariant(t *testing.T, a *API) {
 func testFixture(t *testing.T, a *API) {
 	lang := uof.LangEN
 	f, err := a.Fixture(lang, "sr:match:8696826")
-	assert.Nil(t, err)
-	assert.Equal(t, "IK Oddevold", f.Home.Name)
-	// for fixtures raw response should be kept
-	assert.NotEqual(t, 0, len(f.Raw))
-	if testing.Verbose() && len(f.Raw) != 0 {
-		// strip <?xml version="1.0" encoding="UTF-8"?>
-		fmt.Printf("\t%s\n", f.Raw[39:100])
-	}
+	assert.NoError(t, err)
+	assert.NotEqual(t, 0, len(f))
+	assert.NotEqual(t, -1, bytes.Index(f, []byte("sr:match:8696826")))
+	assert.NotEqual(t, -1, bytes.Index(f, []byte("IK Oddevold")))
 }
 
 func testPlayer(t *testing.T, a *API) {

--- a/api/sports.go
+++ b/api/sports.go
@@ -28,9 +28,12 @@ func (a *API) MarketVariant(lang uof.Lang, marketID int, variant string) (uof.Ma
 }
 
 // Fixture lists the fixture for a specified sport event
-func (a *API) Fixture(lang uof.Lang, eventURN uof.URN) (*uof.Fixture, error) {
-	var fr fixtureRsp
-	return &fr.Fixture, a.getAs(&fr, pathFixture, &params{Lang: lang, EventURN: eventURN})
+func (a *API) Fixture(lang uof.Lang, eventURN uof.URN) ([]byte, error) {
+	buf, err := a.get(pathFixture, &params{Lang: lang, EventURN: eventURN})
+	if err != nil {
+		return nil, err
+	}
+	return buf, err
 }
 
 func (a *API) Player(lang uof.Lang, playerID int) (*uof.Player, error) {

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -96,7 +96,7 @@ func logMessage(m *uof.Message) {
 	case uof.MessageTypeConnection:
 		fmt.Printf("%-25s status: %s\n", m.Type, m.Connection.Status)
 	case uof.MessageTypeFixture:
-		fmt.Printf("%-25s lang: %s, urn: %s raw: %d\n", m.Type, m.Lang, m.Fixture.URN, len(m.Fixture.Raw))
+		fmt.Printf("%-25s lang: %s, urn: %s raw: %d\n", m.Type, m.Lang, m.Fixture.URN, len(m.Raw))
 	case uof.MessageTypeMarkets:
 		fmt.Printf("%-25s lang: %s, count: %d\n", m.Type, m.Lang, len(m.Markets))
 	case uof.MessageTypeAlive:

--- a/fixture.go
+++ b/fixture.go
@@ -44,7 +44,6 @@ type Fixture struct {
 	Away Competitor `json:"away"`
 
 	ExtraInfo []ExtraInfo `xml:"extra_info>info,omitempty" json:"extraInfo,omitempty"`
-	Raw       []byte      // fixture API raw XML response; keep for downstream processing
 	// this also exists but we are skiping for the time being
 	//ReferenceIDs         ReferenceIDs         `xml:"reference_ids,omitempty" json:"referenceIDs,omitempty"`
 	//SportEventConditions SportEventConditions `xml:"sport_event_conditions,omitempty" json:"sportEventConditions,omitempty"`

--- a/message.go
+++ b/message.go
@@ -293,9 +293,30 @@ func NewFixtureMessage(lang Lang, x Fixture, requestedAt int) *Message {
 			ReceivedAt:  uniqTimestamp(),
 			RequestedAt: requestedAt,
 		},
-		Raw:  x.Raw,
 		Body: Body{Fixture: &x},
 	}
+}
+
+// NewFixtureMessageFromBuf creates uof.Message from fixture API response XML ([]byte)
+// message is created from raw XML response in order to save it in the message
+func NewFixtureMessageFromBuf(lang Lang, buf []byte, requestedAt int) (*Message, error) {
+	m := &Message{
+		Header: Header{
+			Type:        MessageTypeFixture,
+			Lang:        lang,
+			ReceivedAt:  uniqTimestamp(),
+			RequestedAt: requestedAt,
+		},
+		Raw: buf, // keep raw
+	}
+	if err := m.unpack(); err != nil {
+		return nil, err
+	}
+	if m.Fixture != nil { // if buf == nil
+		m.EventURN = m.Fixture.URN
+		m.EventID = m.Fixture.ID
+	}
+	return m, nil
 }
 
 func (m *Message) NewFixtureMessage(lang Lang, f Fixture) *Message {

--- a/message_test.go
+++ b/message_test.go
@@ -1,6 +1,7 @@
 package uof
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -265,6 +266,15 @@ func TestNewMessage(t *testing.T) {
 
 	m.NewFixtureMessage(LangEN, Fixture{})
 	assert.True(t, m.Is(MessageTypeFixture))
+}
+
+func TestNewMessageFromBufFail(t *testing.T) {
+	failing := []byte{}
+	expectErr := fmt.Errorf("NOTICE uof error op: message.unpack, inner: EOF")
+	m, err := NewFixtureMessageFromBuf(LangEN, failing, 0)
+	assert.Nil(t, m)
+	assert.Error(t, err)
+	assert.EqualError(t, err, expectErr.Error())
 }
 
 func TestUnpackFail(t *testing.T) {

--- a/message_test.go
+++ b/message_test.go
@@ -259,6 +259,10 @@ func TestNewMessage(t *testing.T) {
 	m = NewFixtureMessage(LangEN, Fixture{}, 0)
 	assert.True(t, m.Is(MessageTypeFixture))
 
+	m, err := NewFixtureMessageFromBuf(LangEN, nil, 0)
+	assert.NoError(t, err)
+	assert.True(t, m.Is(MessageTypeFixture))
+
 	m.NewFixtureMessage(LangEN, Fixture{})
 	assert.True(t, m.Is(MessageTypeFixture))
 }

--- a/parsing_test.go
+++ b/parsing_test.go
@@ -334,14 +334,11 @@ func TestFixture(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, f, *msgAPI.Fixture)
 
-	f.Raw = buf // enrich with raw API reponse
 	requestedAt := int(time.Now().UnixNano() / 1e6)
-	msgFromFix := NewFixtureMessage(LangEN, f, requestedAt)
-	assert.NotNil(t, msgFromFix)
-	assert.NotEqual(t, 0, len(msgFromFix.Raw))
-	assert.Len(t, msgFromFix.Raw, 5283)
-	assert.Len(t, msgFromFix.Fixture.Raw, 5283)
-	assert.Equal(t, &msgFromFix.Fixture.Raw, &msgFromFix.Raw)
+	msgFormBuf, err := NewFixtureMessageFromBuf(LangEN, buf, requestedAt)
+	assert.NotNil(t, msgFormBuf)
+	assert.NotEqual(t, 0, len(msgFormBuf.Raw))
+	assert.Len(t, msgFormBuf.Raw, 5283)
 }
 
 func TestFixutreWithPlayers(t *testing.T) {

--- a/pipe/fixture.go
+++ b/pipe/fixture.go
@@ -8,7 +8,7 @@ import (
 )
 
 type fixtureAPI interface {
-	Fixture(lang uof.Lang, eventURN uof.URN) (*uof.Fixture, error)
+	Fixture(lang uof.Lang, eventURN uof.URN) ([]byte, error)
 	Fixtures(lang uof.Lang, to time.Time) (<-chan uof.Fixture, <-chan error)
 }
 
@@ -129,12 +129,17 @@ func (f *fixture) getFixture(eventURN uof.URN, receivedAt int) {
 			if f.em.fresh(key) {
 				return
 			}
-			x, err := f.api.Fixture(lang, eventURN)
+			buf, err := f.api.Fixture(lang, eventURN)
 			if err != nil {
 				f.errc <- err
 				return
 			}
-			f.out <- uof.NewFixtureMessage(lang, *x, receivedAt)
+			m, err := uof.NewFixtureMessageFromBuf(lang, buf, receivedAt)
+			if err != nil {
+				f.errc <- err
+				return
+			}
+			f.out <- m
 			f.em.insert(key)
 		}(lang)
 	}

--- a/pipe/fixture_test.go
+++ b/pipe/fixture_test.go
@@ -16,10 +16,11 @@ type fixtureAPIMock struct {
 	sync.Mutex
 }
 
-func (m *fixtureAPIMock) Fixture(lang uof.Lang, eventURN uof.URN) (*uof.Fixture, error) {
+func (m *fixtureAPIMock) Fixture(lang uof.Lang, eventURN uof.URN) ([]byte, error) {
 	m.eventURN = eventURN
-	return &uof.Fixture{}, nil
+	return nil, nil
 }
+
 func (m *fixtureAPIMock) Fixtures(lang uof.Lang, to time.Time) (<-chan uof.Fixture, <-chan error) {
 	m.preloadTo = to
 	out := make(chan uof.Fixture)


### PR DESCRIPTION
Allows keeping raw API reponse body for Fixtures requested from API as a result of a fixture_change message.