### PR TITLE
handle players as market specifiers

### DIFF
--- a/odds_change.go
+++ b/odds_change.go
@@ -206,6 +206,15 @@ func (o *OddsChange) EachPlayer(handler func(int)) {
 				handler(id)
 			}
 		}
+		// fetch player if provided as market specifier
+		// <market id="888" specifiers="player=sr:player:575270">
+		// <market id="891" specifiers="goalnr=1|player=sr:player:833167">
+		if playerID, ok := m.Specifiers["player"]; ok {
+			id, err := strconv.Atoi(playerID)
+			if err == nil {
+				handler(id)
+			}
+		}
 	}
 }
 

--- a/testdata/odds_change-0.xml
+++ b/testdata/odds_change-0.xml
@@ -81,5 +81,17 @@
             <outcome id="sr:point_range:76+:1135" odds="6.0" probabilities="0.138334557" active="1"/>
             <outcome id="sr:point_range:76+:1136" odds="6.25" probabilities="0.1324283589" active="1"/>
         </market>
+        <market favourite="1" status="1" id="888" specifiers="player=sr:player:361790">
+            <outcome id="1894" odds="12.0" probabilities="0.0516717989" active="1"/>
+            <outcome id="1895" odds="11.75" probabilities="0.0528440917" active="1"/>
+            <outcome id="1896" odds="5.25" probabilities="0.1211369617" active="1"/>
+            <outcome id="1897" odds="1.01" active="1"/>
+        </market>
+        <market favourite="1" status="1" id="891" specifiers="goalnr=1|player=sr:player:122702">
+            <outcome id="1894" odds="6.0" active="1"/>
+            <outcome id="1895" odds="40.0" active="1"/>
+            <outcome id="1896" odds="100.0" active="1"/>
+            <outcome id="1897" odds="1.01" active="1"/>
+        </market>
     </odds>
 </odds_change>


### PR DESCRIPTION
For markets 888 and 891 (soccer combo markets => goalscorer + game) the playerID is not provided in outcome line but as market specifier. 

For this purpose, player fetching from BR API needs to be executed if a player id (sr:player:integer) is supplied as the market specifier.