### PR TITLE
Changes in response to UOF production environment relocation (virtuals)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -15,8 +15,9 @@ import (
 )
 
 const (
-	stagingServer    = "stgapi.betradar.com"
-	productionServer = "api.betradar.com"
+	stagingServer          = "stgapi.betradar.com"
+	productionServer       = "api.betradar.com"
+	productionServerGlobal = "global.api.betradar.com"
 )
 
 var RequestTimeout = 32 * time.Second
@@ -36,6 +37,8 @@ func Dial(ctx context.Context, env uof.Environment, token string) (*API, error) 
 		return Staging(ctx, token)
 	case uof.Production:
 		return Production(ctx, token)
+	case uof.ProductionGlobal:
+		return ProductionGlobal(ctx, token)
 	default:
 		return nil, uof.Notice("queue dial", fmt.Errorf("unknown environment %d", env))
 	}
@@ -55,6 +58,16 @@ func Staging(exitSig context.Context, token string) (*API, error) {
 func Production(exitSig context.Context, token string) (*API, error) {
 	a := &API{
 		server:  productionServer,
+		token:   token,
+		exitSig: exitSig,
+	}
+	return a, a.Ping()
+}
+
+// Production connects to the production system
+func ProductionGlobal(exitSig context.Context, token string) (*API, error) {
+	a := &API{
+		server:  productionServerGlobal,
 		token:   token,
 		exitSig: exitSig,
 	}

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -96,7 +96,7 @@ func logMessages(in <-chan *uof.Message) error {
 func logMessage(m *uof.Message) {
 	switch m.Type {
 	case uof.MessageTypeConnection:
-		fmt.Printf("%-25s status: %s\n", m.Type, m.Connection.Status)
+		fmt.Printf("%-25s status: %s, server: %s, local: %s, network: %s, tls: %s\n", m.Type, m.Connection.Status, m.Connection.ServerName, m.Connection.LocalAddr, m.Connection.Network, m.Connection.TLSVersionToString())
 	case uof.MessageTypeFixture:
 		fmt.Printf("%-25s lang: %s, urn: %s\n", m.Type, m.Lang, m.Fixture.URN)
 	case uof.MessageTypeMarkets:

--- a/cmd/virtual/main.go
+++ b/cmd/virtual/main.go
@@ -93,7 +93,7 @@ func logMessages(in <-chan *uof.Message) error {
 func logMessage(m *uof.Message) {
 	switch m.Type {
 	case uof.MessageTypeConnection:
-		fmt.Printf("%-25s status: %s\n", m.Type, m.Connection.Status)
+		fmt.Printf("%-25s status: %s, server: %s, local: %s, network: %s, tls: %s\n", m.Type, m.Connection.Status, m.Connection.ServerName, m.Connection.LocalAddr, m.Connection.Network, m.Connection.TLSVersionToString())
 	case uof.MessageTypeFixture:
 		fmt.Printf("%-25s lang: %s, urn: %s raw: %d\n", m.Type, m.Lang, m.Fixture.URN, len(m.Raw))
 	case uof.MessageTypeMarkets:

--- a/enum.go
+++ b/enum.go
@@ -510,4 +510,5 @@ const (
 	Production Environment = iota
 	Staging
 	Replay
+	ProductionGlobal
 )

--- a/internal.go
+++ b/internal.go
@@ -1,8 +1,11 @@
 package uof
 
 type Connection struct {
-	Status    ConnectionStatus `json:"status"`
-	Timestamp int              `json:"timestamp,omitempty"`
+	Status      ConnectionStatus `json:"status"`
+	Timestamp   int              `json:"timestamp,omitempty"`
+	NetworkName string           `json:"networkname,omitempty"`
+	LocalAddr   string           `json:"localaddr,omitempty"`
+	TLSVersion  uint16           `json:"tlsversion,omitempty"`
 }
 
 type ConnectionStatus int8

--- a/internal.go
+++ b/internal.go
@@ -1,11 +1,12 @@
 package uof
 
 type Connection struct {
-	Status      ConnectionStatus `json:"status"`
-	Timestamp   int              `json:"timestamp,omitempty"`
-	NetworkName string           `json:"networkname,omitempty"`
-	LocalAddr   string           `json:"localaddr,omitempty"`
-	TLSVersion  uint16           `json:"tlsversion,omitempty"`
+	Status     ConnectionStatus `json:"status"`
+	Timestamp  int              `json:"timestamp,omitempty"`
+	ServerName string           `json:"servername,omitempty"`
+	LocalAddr  string           `json:"localaddr,omitempty"`
+	Network    string           `json:"network,omitempty"`
+	TLSVersion uint16           `json:"tlsversion,omitempty"`
 }
 
 type ConnectionStatus int8

--- a/internal.go
+++ b/internal.go
@@ -1,5 +1,7 @@
 package uof
 
+import "crypto/tls"
+
 type Connection struct {
 	Status     ConnectionStatus `json:"status"`
 	Timestamp  int              `json:"timestamp,omitempty"`
@@ -7,6 +9,20 @@ type Connection struct {
 	LocalAddr  string           `json:"localaddr,omitempty"`
 	Network    string           `json:"network,omitempty"`
 	TLSVersion uint16           `json:"tlsversion,omitempty"`
+}
+
+func (c Connection) TLSVersionToString() string {
+	switch c.TLSVersion {
+	case tls.VersionTLS10:
+		return "1.0"
+	case tls.VersionTLS11:
+		return "1.1"
+	case tls.VersionTLS12:
+		return "1.2"
+	case tls.VersionTLS13:
+		return "1.3"
+	}
+	return "unknown"
 }
 
 type ConnectionStatus int8

--- a/message.go
+++ b/message.go
@@ -276,7 +276,7 @@ func NewCompetitorMessage(lang Lang, competitor *CompetitorPlayer, requestedAt i
 	}
 }
 
-func NewConnnectionMessage(status ConnectionStatus) *Message {
+func NewSimpleConnnectionMessage(status ConnectionStatus) *Message {
 	ts := uniqTimestamp()
 	return &Message{
 		Header: Header{
@@ -288,6 +288,26 @@ func NewConnnectionMessage(status ConnectionStatus) *Message {
 			Connection: &Connection{
 				Status:    status,
 				Timestamp: ts,
+			},
+		},
+	}
+}
+
+func NewDetailedConnnectionMessage(status ConnectionStatus, networkName, localAddr string, tlsVersion uint16) *Message {
+	ts := uniqTimestamp()
+	return &Message{
+		Header: Header{
+			Type:       MessageTypeConnection,
+			Scope:      MessageScopeSystem,
+			ReceivedAt: ts,
+		},
+		Body: Body{
+			Connection: &Connection{
+				Status:      status,
+				Timestamp:   ts,
+				NetworkName: networkName,
+				LocalAddr:   localAddr,
+				TLSVersion:  tlsVersion,
 			},
 		},
 	}

--- a/message.go
+++ b/message.go
@@ -293,7 +293,7 @@ func NewSimpleConnnectionMessage(status ConnectionStatus) *Message {
 	}
 }
 
-func NewDetailedConnnectionMessage(status ConnectionStatus, networkName, localAddr string, tlsVersion uint16) *Message {
+func NewDetailedConnnectionMessage(status ConnectionStatus, serverName, localAddr, network string, tlsVersion uint16) *Message {
 	ts := uniqTimestamp()
 	return &Message{
 		Header: Header{
@@ -303,11 +303,12 @@ func NewDetailedConnnectionMessage(status ConnectionStatus, networkName, localAd
 		},
 		Body: Body{
 			Connection: &Connection{
-				Status:      status,
-				Timestamp:   ts,
-				NetworkName: networkName,
-				LocalAddr:   localAddr,
-				TLSVersion:  tlsVersion,
+				Status:     status,
+				Timestamp:  ts,
+				ServerName: serverName,
+				LocalAddr:  localAddr,
+				Network:    network,
+				TLSVersion: tlsVersion,
 			},
 		},
 	}

--- a/message_test.go
+++ b/message_test.go
@@ -244,7 +244,7 @@ func TestUIDWithLang(t *testing.T) {
 }
 
 func TestNewMessage(t *testing.T) {
-	m := NewConnnectionMessage(ConnectionStatusUp)
+	m := NewSimpleConnnectionMessage(ConnectionStatusUp)
 	assert.True(t, m.Is(MessageTypeConnection))
 
 	m = NewPlayerMessage(LangEN, nil, 0)

--- a/pipe/fixture_test.go
+++ b/pipe/fixture_test.go
@@ -47,7 +47,7 @@ func TestFixturePipe(t *testing.T) {
 	out, _ := f(in)
 
 	// this type of message is passing through
-	m := uof.NewConnnectionMessage(uof.ConnectionStatusUp)
+	m := uof.NewSimpleConnnectionMessage(uof.ConnectionStatusUp)
 	in <- m
 	om := <-out
 	assert.Equal(t, m, om)

--- a/pipe/market_test.go
+++ b/pipe/market_test.go
@@ -34,7 +34,7 @@ func TestMarketsPipe(t *testing.T) {
 	out, _ := ms(in)
 
 	// this type of message is passing through
-	m := uof.NewConnnectionMessage(uof.ConnectionStatusUp)
+	m := uof.NewSimpleConnnectionMessage(uof.ConnectionStatusUp)
 	in <- m
 	om := <-out
 	assert.Equal(t, m, om)

--- a/pipe/player_test.go
+++ b/pipe/player_test.go
@@ -30,7 +30,7 @@ func TestPlayerPipe(t *testing.T) {
 	out, _ := p(in)
 
 	// this type of message is passing through
-	m := uof.NewConnnectionMessage(uof.ConnectionStatusUp)
+	m := uof.NewSimpleConnnectionMessage(uof.ConnectionStatusUp)
 	in <- m
 	om := <-out
 	assert.Equal(t, m, om)

--- a/pipe/recovery_test.go
+++ b/pipe/recovery_test.go
@@ -125,7 +125,7 @@ func TestRecoveryRequests(t *testing.T) {
 	go r.loop(in, out, errc)
 
 	// 1. connection status triggers recovery requests
-	in <- uof.NewConnnectionMessage(uof.ConnectionStatusUp)
+	in <- uof.NewSimpleConnnectionMessage(uof.ConnectionStatusUp)
 	recoveryRequestPrematch := <-m.calls
 	recoveryRequestLive := <-m.calls
 	if recoveryRequestPrematch.producer == uof.ProducerLiveOdds {

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -15,11 +15,12 @@ import (
 )
 
 const (
-	replayServer     = "replaymq.betradar.com:5671"
-	stagingServer    = "stgmq.betradar.com:5671"
-	productionServer = "mq.betradar.com:5671"
-	queueExchange    = "unifiedfeed"
-	bindingKeyAll    = "#"
+	replayServer           = "replaymq.betradar.com:5671"
+	stagingServer          = "stgmq.betradar.com:5671"
+	productionServer       = "mq.betradar.com:5671"
+	productionServerGlobal = "global.mq.betradar.com:5671"
+	queueExchange          = "unifiedfeed"
+	bindingKeyAll          = "#"
 	// Unless you are binding to all messages (“#”), you will typically bind to
 	// at least two routing key patterns (e.g. “*.*.live.#” and “-.-.-.#”)
 	// because you are typically always interested in receiving the system
@@ -47,6 +48,8 @@ func Dial(ctx context.Context, env uof.Environment, bookmakerID, token string, b
 		return DialStaging(ctx, bookmakerID, token, bind)
 	case uof.Production:
 		return DialProduction(ctx, bookmakerID, token, bind)
+	case uof.ProductionGlobal:
+		return DialProductionGlobal(ctx, bookmakerID, token, bind)
 	default:
 		return nil, uof.Notice("queue dial", fmt.Errorf("unknown environment %d", env))
 	}
@@ -55,6 +58,11 @@ func Dial(ctx context.Context, env uof.Environment, bookmakerID, token string, b
 // Dial connects to the production queue
 func DialProduction(ctx context.Context, bookmakerID, token string, bind int8) (*Connection, error) {
 	return dial(ctx, productionServer, bookmakerID, token, bind)
+}
+
+// Dial connects to the production queue
+func DialProductionGlobal(ctx context.Context, bookmakerID, token string, bind int8) (*Connection, error) {
+	return dial(ctx, productionServerGlobal, bookmakerID, token, bind)
 }
 
 // DialStaging connects to the staging queue

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -83,9 +83,10 @@ type Connection struct {
 }
 
 type ConnectionInfo struct {
-	networkName string
-	localAddr   string
-	tlsVersion  uint16
+	server     string
+	local      string
+	network    string
+	tlsVersion uint16
 }
 
 func (c *Connection) Listen() (<-chan *uof.Message, <-chan error) {
@@ -202,9 +203,10 @@ func dial(ctx context.Context, server, bookmakerID, token string, bind int8) (*C
 			return dial(ctx, server, bookmakerID, token, bind)
 		},
 		info: ConnectionInfo{
-			networkName: conn.LocalAddr().Network(),
-			localAddr:   conn.LocalAddr().String(),
-			tlsVersion:  conn.ConnectionState().Version,
+			server:     server,
+			local:      conn.LocalAddr().String(),
+			network:    conn.LocalAddr().Network(),
+			tlsVersion: conn.ConnectionState().Version,
 		},
 	}
 

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -79,6 +79,13 @@ type Connection struct {
 	msgs   <-chan amqp.Delivery
 	errs   <-chan *amqp.Error
 	reDial func() (*Connection, error)
+	info   ConnectionInfo
+}
+
+type ConnectionInfo struct {
+	networkName string
+	localAddr   string
+	tlsVersion  uint16
 }
 
 func (c *Connection) Listen() (<-chan *uof.Message, <-chan error) {
@@ -193,6 +200,11 @@ func dial(ctx context.Context, server, bookmakerID, token string, bind int8) (*C
 		errs: errs,
 		reDial: func() (*Connection, error) {
 			return dial(ctx, server, bookmakerID, token, bind)
+		},
+		info: ConnectionInfo{
+			networkName: conn.LocalAddr().Network(),
+			localAddr:   conn.LocalAddr().String(),
+			tlsVersion:  conn.ConnectionState().Version,
 		},
 	}
 

--- a/queue/reconnect.go
+++ b/queue/reconnect.go
@@ -44,12 +44,14 @@ func WithReconnect(ctx context.Context, conn *Connection) func() (<-chan *uof.Me
 			defer close(out)
 			defer close(errc)
 			for {
-				out <- uof.NewConnnectionMessage(uof.ConnectionStatusUp) // signal connect
+				// signal connect
+				out <- uof.NewDetailedConnnectionMessage(uof.ConnectionStatusUp, conn.info.networkName, conn.info.localAddr, conn.info.tlsVersion)
 				conn.drain(out, errc)
 				if done() {
 					return
 				}
-				out <- uof.NewConnnectionMessage(uof.ConnectionStatusDown) // signal connection lost
+				// signal connection lost
+				out <- uof.NewSimpleConnnectionMessage(uof.ConnectionStatusDown)
 				if err := withBackoff(ctx, reconnect, maxInterval, maxElapsedTime); err != nil {
 					return
 				}

--- a/queue/reconnect.go
+++ b/queue/reconnect.go
@@ -45,7 +45,7 @@ func WithReconnect(ctx context.Context, conn *Connection) func() (<-chan *uof.Me
 			defer close(errc)
 			for {
 				// signal connect
-				out <- uof.NewDetailedConnnectionMessage(uof.ConnectionStatusUp, conn.info.networkName, conn.info.localAddr, conn.info.tlsVersion)
+				out <- uof.NewDetailedConnnectionMessage(uof.ConnectionStatusUp, conn.info.server, conn.info.local, conn.info.network, conn.info.tlsVersion)
 				conn.drain(out, errc)
 				if done() {
 					return

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -20,7 +20,6 @@ type Config struct {
 	Stages       []pipe.InnerStage
 	Replay       func(*api.ReplayAPI) error
 	Env          uof.Environment
-	Staging      bool
 	BindVirtuals bool
 	BindSports   bool
 	BindPrematch bool
@@ -142,7 +141,6 @@ func Languages(langs []uof.Lang) Option {
 func Staging() Option {
 	return func(c *Config) {
 		c.Env = uof.Staging
-		c.Staging = true
 	}
 }
 

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -137,6 +137,13 @@ func Languages(langs []uof.Lang) Option {
 	}
 }
 
+// Global forces use of global production environment.
+func Global() Option {
+	return func(c *Config) {
+		c.Env = uof.ProductionGlobal
+	}
+}
+
 // Staging forces use of staging environment instead of production.
 func Staging() Option {
 	return func(c *Config) {


### PR DESCRIPTION
Added option to use global production MQ & API endpoints.

Added attributes for transmitting some basic information about the MQ connection in Connection messages.